### PR TITLE
Fix "50 char limitations on brokered service instance name" bug

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/ServiceInstanceNameHelper.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/ServiceInstanceNameHelper.java
@@ -1,0 +1,13 @@
+package org.springframework.cloud.appbroker.extensions.targets;
+
+public class ServiceInstanceNameHelper {
+
+	// See https://github.com/cloudfoundry/cloud_controller_ng/blob/757a9d4d6f41b57ccba7b2007de2d51fbf1a4385/vendor/errors/v2.yml#L231-L235
+	// > You have requested an invalid service instance name. Names are limited to 50 characters
+	public static final int MAX_CF_SERVICE_INSTANCE_NAME_LENGTH = 50;
+
+	public static String truncateNameToCfMaxSize(String name) {
+		return name.substring(0, Math.min(name.length(), MAX_CF_SERVICE_INSTANCE_NAME_LENGTH));
+	}
+
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinition.java
@@ -31,12 +31,15 @@ public class SpacePerServiceDefinition extends TargetFactory<SpacePerServiceDefi
 		return this::apply;
 	}
 
-	private ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId, String backingServiceName, String backingServicePlanName) {
+	protected ArtifactDetails apply(Map<String, String> properties, String name,
+		String brokeredServiceInstanceId,
+		String backingServiceName, String backingServicePlanName) {
 		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, backingServiceName);
+		//space names are unlimited in CF
 		properties.put(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true");
 
 		return ArtifactDetails.builder()
-			.name(name + "-" + brokeredServiceInstanceId)
+			.name(ServiceInstanceNameHelper.truncateNameToCfMaxSize(brokeredServiceInstanceId))
 			.properties(properties)
 			.build();
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlan.java
@@ -31,12 +31,15 @@ public class SpacePerServicePlan extends TargetFactory<SpacePerServicePlan.Confi
 		return this::apply;
 	}
 
-	private ArtifactDetails apply(Map<String, String> properties, String name, String brokeredServiceInstanceId, String backingServiceName, String backingServicePlanName) {
+	protected ArtifactDetails apply(Map<String, String> properties, String name,
+		String brokeredServiceInstanceId,
+		String backingServiceName, String backingServicePlanName) {
 		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, backingServiceName + "-" + backingServicePlanName);
+		//space names are unlimited in CF
 		properties.put(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true");
 
 		return ArtifactDetails.builder()
-			.name(name + "-" + brokeredServiceInstanceId)
+			.name(ServiceInstanceNameHelper.truncateNameToCfMaxSize(brokeredServiceInstanceId))
 			.properties(properties)
 			.build();
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/TargetFactory.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/targets/TargetFactory.java
@@ -34,4 +34,5 @@ public abstract class TargetFactory<C> extends AbstractExtensionFactory<Target, 
 	public String getName() {
 		return getShortName(TargetFactory.class);
 	}
+
 }

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/targets/AbstractServiceInstanceGuidAsServiceInstanceNameTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/targets/AbstractServiceInstanceGuidAsServiceInstanceNameTest.java
@@ -1,0 +1,44 @@
+package org.springframework.cloud.appbroker.extensions.targets;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractServiceInstanceGuidAsServiceInstanceNameTest {
+
+	protected TargetFactory strategy;
+
+	@Test
+	void serviceInstanceNameUseServiceInstanceGuid() {
+		//more than 13 chars
+		ArtifactDetails artifactDetails = generateArtifact("Any-service-name-Does-not-get-used", "99643ba8-8805-4a2b-a059-c62bc1ea5cf1");
+		assertThat(artifactDetails.getName()).isEqualTo("99643ba8-8805-4a2b-a059-c62bc1ea5cf1");
+	}
+
+	@Test
+	void serviceInstanceNamesAreShorterThanCfLimit() {
+		assertServiceInstanceNameIsSmallerThanCfLimit("Any-service-name-Does-not-get-used",   //more than 13 chars
+			"0123456789"+ "0123456789"+ "0123456789"+ "0123456789"+"0123456789"+"0123456789"+"0123456789"+"0123456789"
+		);
+		assertServiceInstanceNameIsSmallerThanCfLimit("p-mysql",
+			"99643ba8-8805-4a2b-a059-c62bc1ea5cf1" //36 chars
+		);
+		assertServiceInstanceNameIsSmallerThanCfLimit("p-mysql",
+			"33ffdf64-784d-4ecb-8e70-17d54b2a73" //34 chars
+		);
+	}
+
+	private void assertServiceInstanceNameIsSmallerThanCfLimit(String serviceOfferingName, String serviceInstanceId) {
+		ArtifactDetails artifactDetails = generateArtifact(serviceOfferingName, serviceInstanceId);
+		assertThat(artifactDetails.getName()).hasSizeLessThanOrEqualTo(50);
+	}
+
+	protected ArtifactDetails generateArtifact(String serviceOfferingName, String serviceInstanceId) {
+		Target target = strategy.create(null);
+		return target
+			.apply(new HashMap<>(), serviceOfferingName, serviceInstanceId, serviceOfferingName, "10mb");
+	}
+
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinitionTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServiceDefinitionTest.java
@@ -1,0 +1,36 @@
+package org.springframework.cloud.appbroker.extensions.targets;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpacePerServiceDefinitionTest extends AbstractServiceInstanceGuidAsServiceInstanceNameTest {
+
+	@BeforeAll
+	public void beforeEach() {
+		strategy = new SpacePerServiceDefinition();
+	}
+
+	@Test
+	void spaceNameIsServiceDefinition() {
+		//more than 13 chars
+		Target target = strategy.create(null);
+		ArtifactDetails artifactDetails = target
+			.apply(new HashMap<>(), "A-brokered-service-name", "a-service-guid",
+				"p-mysql", "10mb");
+		assertThat(artifactDetails.getProperties()).containsOnly(
+			entry(DeploymentProperties.TARGET_PROPERTY_KEY, "p-mysql"),
+			entry(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true")
+		);
+	}
+
+
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlanTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/targets/SpacePerServicePlanTest.java
@@ -1,0 +1,36 @@
+package org.springframework.cloud.appbroker.extensions.targets;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import org.springframework.cloud.appbroker.deployer.DeploymentProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpacePerServicePlanTest extends AbstractServiceInstanceGuidAsServiceInstanceNameTest {
+
+	@BeforeAll
+	public void beforeEach() {
+		strategy = new SpacePerServicePlan();
+	}
+
+	@Test
+	void spaceNameIsServicePlan() {
+		//more than 13 chars
+		Target target = strategy.create(null);
+		ArtifactDetails artifactDetails = target
+			.apply(new HashMap<>(), "A-brokered-service-name", "a-service-guid",
+				"p-mysql", "10mb");
+		assertThat(artifactDetails.getProperties()).containsOnly(
+			entry(DeploymentProperties.TARGET_PROPERTY_KEY, "p-mysql-10mb"),
+			entry(DeploymentProperties.KEEP_TARGET_ON_DELETE_PROPERTY_KEY, "true")
+			);
+	}
+
+
+}


### PR DESCRIPTION
Now backing service instance only uses the brokered service instance guid as name

Fix #18