### PR TITLE
Acceptance tests in concourse pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,21 @@ The following diagram summarizes the interactions between OSB-CMDB and its clien
 
 ![sequence diagram](./osb-cmdb/seq-diagram.png)
 
-### Releasing
+### Contributing
+
+#### Circle ci tests
+
+Circle ci tests run offline without a cloudfoundry instance. They include scab tests and osb-cmdb tests. See osb-cmdb/.circle/config.yml
+
+#### Acceptance tests
+
+Acceptance tests run privately against a live cloudfoundry instance. Tests are private because it is hard to secure logs to not leak credentials that could be used to abuse the Cloud Foundry instance.
+
+See https://github.com/orange-cloudfoundry/osb-cmdb-ci for the concourse task running the acceptance tests.
+
+Like scab, osb-cmdb acceptance tests use distinct properties than osb-cmdb production properties. Refer to [Getting started](#getting-started) for the list of prod properties supported, and paas-templates smoke tests. 
+
+#### Releasing
 
 For the spike, 
 * manually edit the version in `osb-cmdb/gradle.properties` (e.g `version=0.1.0`), commit & push

--- a/osb-cmdb/.circleci/config.yml
+++ b/osb-cmdb/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 #          #Workaround OpenJdk8 regression which crashes JVM. See https://stackoverflow.com/a/53085816
 #          - _JAVA_OPTIONS: "-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
           command: |
-            ./gradlew --continue :osb-cmdb:assemble
+            ./gradlew --continue clean :osb-cmdb:assemble
       - run:
           name: save jar artefacts
           command: |

--- a/osb-cmdb/.circleci/config.yml
+++ b/osb-cmdb/.circleci/config.yml
@@ -50,8 +50,9 @@ jobs:
           #          environment:
           #          #Workaround OpenJdk8 regression which crashes JVM. See https://stackoverflow.com/a/53085816
           #          - _JAVA_OPTIONS: "-Djdk.net.URLClassPath.disableClassPathURLCheck=true"
+          # Note: we exclude AT from circle using junit tags to be flexible on unit tests selection.
           command: |
-            ./gradlew --continue check -x checkstyleNohttp -x checkstyleMain -x checkstyleTest -x pmdMain -x pmdTest
+            ./gradlew --continue -DexcludeTags=AcceptanceTest check -x checkstyleNohttp -x checkstyleMain -x checkstyleTest -x pmdMain -x pmdTest
   build_n_deploy:
     working_directory: ~/osb-cmdb-spike
     docker:

--- a/osb-cmdb/build.gradle
+++ b/osb-cmdb/build.gradle
@@ -86,7 +86,7 @@ test {
 	// Pass relevant java properties to the test task
 	systemProperties << System.properties.findAll {
 		//
-		it.key.startsWith("spring.") || it.key.startsWith("osbcmdb.")
+		it.key.startsWith("spring.") || it.key.startsWith("osbcmdb.")|| it.key.startsWith("debug")
 	}
 }
 

--- a/osb-cmdb/build.gradle
+++ b/osb-cmdb/build.gradle
@@ -66,9 +66,28 @@ test {
 //	onlyIf {
 //		project.hasProperty("acceptanceTests")
 //	}
+
+	//Propagate tags from gradle command line to fine tune test selection
+	//See https://javabydeveloper.com/run-tag-specific-junit-5-tests-from-gradle-command/
+	String itags = System.getProperty("includeTags")
+	String etags = System.getProperty("excludeTags")
+
+	useJUnitPlatform{
+		if (itags !=null) {
+			includeTags  itags
+		}
+		if (etags != null) {
+			excludeTags  etags
+		}
+	}
+
+
 	systemProperty "tests.broker-app-path", "${buildDir}/libs/osb-cmdb.jar"
 	// Pass relevant java properties to the test task
-	systemProperties << System.properties.findAll { it.key.startsWith("spring.") }
+	systemProperties << System.properties.findAll {
+		//
+		it.key.startsWith("spring.") || it.key.startsWith("osbcmdb.")
+	}
 }
 
 gitProperties {

--- a/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/DynamicServiceAutoConfigurationAcceptanceTest.java
+++ b/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/DynamicServiceAutoConfigurationAcceptanceTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orange.oss.osbcmdb.fixtures.CloudFoundryClientConfiguration;
 import com.orange.oss.osbcmdb.fixtures.TargetPropertiesConfiguration;
 import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // Expects the Cf client properties to be injected as system properties
 // and the corresponding Cf marketplace to be non empty
 //Expects the spring profile "acceptanceTests" to be turned on
-@EnabledIfSystemProperty(named = "ACCEPTANCE_TEST", matches = "TRUE")
+@Tag("AcceptanceTest")
 class DynamicServiceAutoConfigurationAcceptanceTest {
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/OsbCmdbApplicationTests.java
+++ b/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/OsbCmdbApplicationTests.java
@@ -1,7 +1,7 @@
 package com.orange.oss.osbcmdb;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -12,7 +12,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 // Expects the Cf client properties to be injected as system properties
 // and the corresponding Cf marketplace to be non empty
-@EnabledIfSystemProperty(named = "ACCEPTANCE_TEST", matches = "TRUE")
+@Tag("ExpectsProdProperties")
+@Tag("AcceptanceTest")
 public class OsbCmdbApplicationTests {
 
     @Test

--- a/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/OsbCmdbApplicationTests.java
+++ b/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/OsbCmdbApplicationTests.java
@@ -1,5 +1,6 @@
 package com.orange.oss.osbcmdb;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
  * Only run OsbCmdbApplicationTests when system properties are properly defined. Exclude them in circle
  */
 @SuppressWarnings("WeakerAccess")
+@Disabled("Replaced by paas-templates smoke tests. Has little value for now. " +
+    "Otherwise would require a dedicated gradle test execution as prod properties conflict with at properties: they override CfDeploymentProperties")
 @SpringBootTest
 // Expects the Cf client properties to be injected as system properties
 // and the corresponding Cf marketplace to be non empty

--- a/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/fixtures/CloudFoundryClientConfiguration.java
+++ b/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/fixtures/CloudFoundryClientConfiguration.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("dynamicCatalog.acceptanceTests")
+@Profile("acceptanceTests")
 @EnableConfigurationProperties(CloudFoundryProperties.class)
 //Inspired from spring-cloud-app-broker-acceptance-tests
 public class CloudFoundryClientConfiguration {

--- a/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/fixtures/TargetPropertiesConfiguration.java
+++ b/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/fixtures/TargetPropertiesConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("dynamicCatalog.acceptanceTests")
+@Profile("acceptanceTests")
 public class TargetPropertiesConfiguration {
 
 	//Inspired from spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CloudFoundryAppDeployerAutoConfiguration.java

--- a/spring-cloud-app-broker-acceptance-tests/build.gradle
+++ b/spring-cloud-app-broker-acceptance-tests/build.gradle
@@ -54,6 +54,7 @@ bootJar {
 }
 
 test {
+
 	maxParallelForks = Runtime.runtime.availableProcessors() - 1 ?: 1
 
 	// Only run the tests if acceptanceTests is specified
@@ -63,4 +64,20 @@ test {
 	systemProperty "tests.broker-app-path", "${buildDir}/libs/spring-cloud-app-broker-acceptance-tests.jar"
 	// Pass relevant java properties to the test task
 	systemProperties << System.properties.findAll { it.key.startsWith("spring.") }
+
+	//Propagate tags from gradle command line to fine tune test selection
+	//See https://javabydeveloper.com/run-tag-specific-junit-5-tests-from-gradle-command/
+	String itags = System.getProperty("includeTags")
+	String etags = System.getProperty("excludeTags")
+
+	useJUnitPlatform{
+		if (itags !=null) {
+			includeTags  itags
+		}
+		if (etags != null) {
+			excludeTags  etags
+		}
+	}
+
+
 }


### PR DESCRIPTION
Supports tests running in orange concourse pipeline:
- now allows junit tag selection from gradle cmd line 
- propagate gradle jvm system properties to tests (like scab AT + osb-cmbd specific properties + spring debug)
- cleans gradle at each circle ci build